### PR TITLE
Add support for disabling non-pointer Set cases in interface_type plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ type MsgCodec interface {
 
 The types `A`, `B`, and `C` must of course have implementations of `Msg`.
 
+### Handling Non-Pointer Interfaces
+
+By default `interface_type` generates `Set` handlers for both pointer and non-pointer
+implementations of an interface (i.e. both `*A` and `A`). This means all interfaces
+must be implemented for the non-pointer version of a struct. To disable the non-pointer
+cases (so that just `*A` and not `A` needs to implement the interface), the interface
+type name can be prepended with a `*`, ex: `option (cosmos_proto.interface_type) = "*my_package.Msg";`.
+

--- a/interfacetype/interfacetype.go
+++ b/interfacetype/interfacetype.go
@@ -47,6 +47,11 @@ func (p *interfacetype) Generate(file *generator.FileDescriptor) {
 		if len(iface) == 0 {
 			continue
 		}
+		handleNonPointer := true
+		if iface[0] == '*' {
+			iface = iface[1:]
+			handleNonPointer = false
+		}
 		if len(message.OneofDecl) != 1 {
 			panic("interfacetype only supports messages with exactly one oneof declaration")
 		}
@@ -100,13 +105,15 @@ func (p *interfacetype) Generate(file *generator.FileDescriptor) {
 			p.P(`this.`, oneofName, ` = &`, structName, `{vt}`)
 			p.P("return nil")
 			p.Out()
-			// Handle non-pointer case
-			if goTyp[0] == '*' {
-				p.P(`case `, goTyp[1:], `:`)
-				p.In()
-				p.P(`this.`, oneofName, ` = &`, structName, `{&vt}`)
-				p.P("return nil")
-				p.Out()
+			if handleNonPointer {
+				// Handle non-pointer case
+				if goTyp[0] == '*' {
+					p.P(`case `, goTyp[1:], `:`)
+					p.In()
+					p.P(`this.`, oneofName, ` = &`, structName, `{&vt}`)
+					p.P("return nil")
+					p.Out()
+				}
 			}
 		}
 		p.P(`}`)

--- a/test/abc.pb.go
+++ b/test/abc.pb.go
@@ -122,6 +122,104 @@ func (*ABC) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+type ABCNonPointer struct {
+	// Types that are valid to be assigned to Sum:
+	//	*ABCNonPointer_A
+	//	*ABCNonPointer_B
+	//	*ABCNonPointer_C
+	Sum isABCNonPointer_Sum `protobuf_oneof:"sum"`
+}
+
+func (m *ABCNonPointer) Reset()         { *m = ABCNonPointer{} }
+func (m *ABCNonPointer) String() string { return proto.CompactTextString(m) }
+func (*ABCNonPointer) ProtoMessage()    {}
+func (*ABCNonPointer) Descriptor() ([]byte, []int) {
+	return fileDescriptor_edbe9e0eab89a1a7, []int{1}
+}
+func (m *ABCNonPointer) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ABCNonPointer) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ABCNonPointer.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ABCNonPointer) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ABCNonPointer.Merge(m, src)
+}
+func (m *ABCNonPointer) XXX_Size() int {
+	return m.Size()
+}
+func (m *ABCNonPointer) XXX_DiscardUnknown() {
+	xxx_messageInfo_ABCNonPointer.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ABCNonPointer proto.InternalMessageInfo
+
+type isABCNonPointer_Sum interface {
+	isABCNonPointer_Sum()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type ABCNonPointer_A struct {
+	A *A `protobuf:"bytes,1,opt,name=a,proto3,oneof" json:"a,omitempty"`
+}
+type ABCNonPointer_B struct {
+	B *B `protobuf:"bytes,2,opt,name=b,proto3,oneof" json:"b,omitempty"`
+}
+type ABCNonPointer_C struct {
+	C *C `protobuf:"bytes,3,opt,name=c,proto3,oneof" json:"c,omitempty"`
+}
+
+func (*ABCNonPointer_A) isABCNonPointer_Sum() {}
+func (*ABCNonPointer_B) isABCNonPointer_Sum() {}
+func (*ABCNonPointer_C) isABCNonPointer_Sum() {}
+
+func (m *ABCNonPointer) GetSum() isABCNonPointer_Sum {
+	if m != nil {
+		return m.Sum
+	}
+	return nil
+}
+
+func (m *ABCNonPointer) GetA() *A {
+	if x, ok := m.GetSum().(*ABCNonPointer_A); ok {
+		return x.A
+	}
+	return nil
+}
+
+func (m *ABCNonPointer) GetB() *B {
+	if x, ok := m.GetSum().(*ABCNonPointer_B); ok {
+		return x.B
+	}
+	return nil
+}
+
+func (m *ABCNonPointer) GetC() *C {
+	if x, ok := m.GetSum().(*ABCNonPointer_C); ok {
+		return x.C
+	}
+	return nil
+}
+
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ABCNonPointer) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
+		(*ABCNonPointer_A)(nil),
+		(*ABCNonPointer_B)(nil),
+		(*ABCNonPointer_C)(nil),
+	}
+}
+
 type A struct {
 	X int32 `protobuf:"varint,1,opt,name=x,proto3" json:"x,omitempty"`
 }
@@ -130,7 +228,7 @@ func (m *A) Reset()         { *m = A{} }
 func (m *A) String() string { return proto.CompactTextString(m) }
 func (*A) ProtoMessage()    {}
 func (*A) Descriptor() ([]byte, []int) {
-	return fileDescriptor_edbe9e0eab89a1a7, []int{1}
+	return fileDescriptor_edbe9e0eab89a1a7, []int{2}
 }
 func (m *A) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -174,7 +272,7 @@ func (m *B) Reset()         { *m = B{} }
 func (m *B) String() string { return proto.CompactTextString(m) }
 func (*B) ProtoMessage()    {}
 func (*B) Descriptor() ([]byte, []int) {
-	return fileDescriptor_edbe9e0eab89a1a7, []int{2}
+	return fileDescriptor_edbe9e0eab89a1a7, []int{3}
 }
 func (m *B) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -218,7 +316,7 @@ func (m *C) Reset()         { *m = C{} }
 func (m *C) String() string { return proto.CompactTextString(m) }
 func (*C) ProtoMessage()    {}
 func (*C) Descriptor() ([]byte, []int) {
-	return fileDescriptor_edbe9e0eab89a1a7, []int{3}
+	return fileDescriptor_edbe9e0eab89a1a7, []int{4}
 }
 func (m *C) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -256,6 +354,7 @@ func (m *C) GetZ() bool {
 
 func init() {
 	proto.RegisterType((*ABC)(nil), "test.abc.ABC")
+	proto.RegisterType((*ABCNonPointer)(nil), "test.abc.ABCNonPointer")
 	proto.RegisterType((*A)(nil), "test.abc.A")
 	proto.RegisterType((*B)(nil), "test.abc.B")
 	proto.RegisterType((*C)(nil), "test.abc.C")
@@ -264,7 +363,7 @@ func init() {
 func init() { proto.RegisterFile("test/abc.proto", fileDescriptor_edbe9e0eab89a1a7) }
 
 var fileDescriptor_edbe9e0eab89a1a7 = []byte{
-	// 243 bytes of a gzipped FileDescriptorProto
+	// 271 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x2b, 0x49, 0x2d, 0x2e,
 	0xd1, 0x4f, 0x4c, 0x4a, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x00, 0xf1, 0xf5, 0x12,
 	0x93, 0x92, 0xa5, 0x78, 0x92, 0xf3, 0x8b, 0x73, 0xf3, 0x8b, 0x21, 0xe2, 0x4a, 0x73, 0x19, 0xb9,
@@ -274,13 +373,14 @@ var fileDescriptor_edbe9e0eab89a1a7 = []byte{
 	0xd9, 0xca, 0xe2, 0xd4, 0x16, 0x5d, 0x93, 0xf4, 0xcc, 0x92, 0x8c, 0xd2, 0x24, 0xbd, 0xe4, 0xfc,
 	0x5c, 0xfd, 0xa2, 0xd4, 0xf4, 0xd4, 0x3c, 0xdd, 0xbc, 0xd4, 0x92, 0xf2, 0xfc, 0xa2, 0x6c, 0x7d,
 	0x88, 0x4b, 0x74, 0xc1, 0x2e, 0xd1, 0x07, 0x3b, 0x38, 0x33, 0x2d, 0x31, 0x39, 0x55, 0xcf, 0xb7,
-	0x38, 0xdd, 0x89, 0x95, 0x8b, 0xb9, 0xb8, 0x34, 0x57, 0x49, 0x90, 0x8b, 0xd1, 0x51, 0x88, 0x87,
-	0x8b, 0xb1, 0x02, 0xec, 0x38, 0xd6, 0x20, 0xc6, 0x0a, 0x90, 0x90, 0x13, 0x48, 0xa8, 0x12, 0x2c,
-	0xc4, 0x1b, 0xc4, 0x58, 0x09, 0x12, 0x72, 0x06, 0x09, 0x55, 0x81, 0x85, 0x38, 0x82, 0x18, 0xab,
-	0x9c, 0xe4, 0x4e, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x09,
-	0x8f, 0xe5, 0x18, 0x2e, 0x3c, 0x96, 0x63, 0xb8, 0xf1, 0x58, 0x8e, 0x21, 0x8a, 0x05, 0x64, 0x53,
-	0x12, 0x1b, 0xd8, 0x56, 0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xb1, 0x4d, 0x04, 0x1f, 0x29,
-	0x01, 0x00, 0x00,
+	0x38, 0xdd, 0x89, 0x95, 0x8b, 0xb9, 0xb8, 0x34, 0x57, 0x69, 0x05, 0x23, 0x17, 0xaf, 0xa3, 0x93,
+	0xb3, 0x5f, 0x7e, 0x5e, 0x40, 0x7e, 0x66, 0x5e, 0x49, 0x6a, 0x11, 0xad, 0x5c, 0x6a, 0x79, 0x6a,
+	0x8b, 0xae, 0xa9, 0x16, 0x25, 0x4e, 0x15, 0xe4, 0x62, 0x74, 0x14, 0xe2, 0xe1, 0x62, 0xac, 0x00,
+	0xbb, 0x8e, 0x35, 0x88, 0xb1, 0x02, 0x24, 0xe4, 0x04, 0x12, 0xaa, 0x04, 0x0b, 0xf1, 0x06, 0x31,
+	0x56, 0x82, 0x84, 0x9c, 0x41, 0x42, 0x55, 0x60, 0x21, 0x8e, 0x20, 0xc6, 0x2a, 0x27, 0xb9, 0x13,
+	0x8f, 0xe4, 0x18, 0x2f, 0x3c, 0x92, 0x63, 0x7c, 0xf0, 0x48, 0x8e, 0x71, 0xc2, 0x63, 0x39, 0x86,
+	0x0b, 0x8f, 0xe5, 0x18, 0x6e, 0x3c, 0x96, 0x63, 0x88, 0x62, 0x01, 0xd9, 0x94, 0xc4, 0x06, 0xb6,
+	0xd5, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0x92, 0xbc, 0x6f, 0x37, 0xd4, 0x01, 0x00, 0x00,
 }
 
 func (this *ABC) GetMsg() github_com_regen_network_cosmos_proto_test_iface.Msg {
@@ -322,6 +422,38 @@ func (this *ABC) SetMsg(value github_com_regen_network_cosmos_proto_test_iface.M
 		return nil
 	}
 	return fmt.Errorf("can't encode value of type %T as message ABC", value)
+}
+
+func (this *ABCNonPointer) GetMsg() github_com_regen_network_cosmos_proto_test_iface.Msg {
+	if x := this.GetA(); x != nil {
+		return x
+	}
+	if x := this.GetB(); x != nil {
+		return x
+	}
+	if x := this.GetC(); x != nil {
+		return x
+	}
+	return nil
+}
+
+func (this *ABCNonPointer) SetMsg(value github_com_regen_network_cosmos_proto_test_iface.Msg) error {
+	if value == nil {
+		this.Sum = nil
+		return nil
+	}
+	switch vt := value.(type) {
+	case *A:
+		this.Sum = &ABCNonPointer_A{vt}
+		return nil
+	case *B:
+		this.Sum = &ABCNonPointer_B{vt}
+		return nil
+	case *C:
+		this.Sum = &ABCNonPointer_C{vt}
+		return nil
+	}
+	return fmt.Errorf("can't encode value of type %T as message ABCNonPointer", value)
 }
 
 func (m *ABC) Marshal() (dAtA []byte, err error) {
@@ -404,6 +536,101 @@ func (m *ABC_C) MarshalTo(dAtA []byte) (int, error) {
 }
 
 func (m *ABC_C) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.C != nil {
+		{
+			size, err := m.C.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintAbc(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *ABCNonPointer) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ABCNonPointer) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ABCNonPointer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Sum != nil {
+		{
+			size := m.Sum.Size()
+			i -= size
+			if _, err := m.Sum.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ABCNonPointer_A) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ABCNonPointer_A) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.A != nil {
+		{
+			size, err := m.A.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintAbc(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+func (m *ABCNonPointer_B) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ABCNonPointer_B) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.B != nil {
+		{
+			size, err := m.B.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintAbc(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *ABCNonPointer_C) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ABCNonPointer_C) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	if m.C != nil {
 		{
@@ -556,6 +783,54 @@ func (m *ABC_B) Size() (n int) {
 	return n
 }
 func (m *ABC_C) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.C != nil {
+		l = m.C.Size()
+		n += 1 + l + sovAbc(uint64(l))
+	}
+	return n
+}
+func (m *ABCNonPointer) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Sum != nil {
+		n += m.Sum.Size()
+	}
+	return n
+}
+
+func (m *ABCNonPointer_A) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.A != nil {
+		l = m.A.Size()
+		n += 1 + l + sovAbc(uint64(l))
+	}
+	return n
+}
+func (m *ABCNonPointer_B) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.B != nil {
+		l = m.B.Size()
+		n += 1 + l + sovAbc(uint64(l))
+	}
+	return n
+}
+func (m *ABCNonPointer_C) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -742,6 +1017,164 @@ func (m *ABC) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			m.Sum = &ABC_C{v}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAbc(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAbc
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAbc
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ABCNonPointer) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAbc
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ABCNonPointer: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ABCNonPointer: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field A", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAbc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAbc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthAbc
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &A{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Sum = &ABCNonPointer_A{v}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field B", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAbc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAbc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthAbc
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &B{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Sum = &ABCNonPointer_B{v}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field C", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAbc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAbc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthAbc
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &C{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Sum = &ABCNonPointer_C{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/test/abc.proto
+++ b/test/abc.proto
@@ -14,6 +14,15 @@ message ABC {
     }
 }
 
+message ABCNonPointer {
+    option (cosmos_proto.interface_type) = "*github.com/regen-network/cosmos-proto/test/iface.Msg";
+    oneof sum {
+        A a = 1;
+        B b = 2;
+        C c = 3;
+    }
+}
+
 message A {
     int32 x = 1;
 }

--- a/test/iface_test.go
+++ b/test/iface_test.go
@@ -51,3 +51,35 @@ func TestToAndFrom(t *testing.T) {
 	// D implements Msg but isn't in the ABC oneof and so this should fail
 	assert.Error(t, abc.SetMsg(&D{}))
 }
+
+func TestToAndFromNonPointer(t *testing.T) {
+	abc := ABCNonPointer{}
+
+	assert.NoError(t, abc.SetMsg(&A{X: 1}))
+	iface1 := abc.GetMsg()
+	assert.NotNil(t, iface1)
+	assert.Equal(t, "A.X:1", iface1.SomeMethod())
+
+	assert.NoError(t, abc.SetMsg(&B{Y: 2}))
+	iface1 = abc.GetMsg()
+	assert.NotNil(t, iface1)
+	assert.Equal(t, "B.Y:2", iface1.SomeMethod())
+
+	assert.NoError(t, abc.SetMsg(&C{Z: true}))
+	iface1 = abc.GetMsg()
+	assert.NotNil(t, iface1)
+	assert.Equal(t, "C.Z:true", iface1.SomeMethod())
+
+	// Non-pointer cases should error here
+	assert.Error(t, abc.SetMsg(A{X: 1}))
+	assert.Error(t, abc.SetMsg(B{Y: 2}))
+	assert.Error(t, abc.SetMsg(C{Z: true}))
+
+	// test nil
+	assert.NoError(t, abc.SetMsg(nil))
+	iface1 = abc.GetMsg()
+	assert.Nil(t, iface1)
+
+	// D implements Msg but isn't in the ABC oneof and so this should fail
+	assert.Error(t, abc.SetMsg(&D{}))
+}


### PR DESCRIPTION
Prepending interface type names with a `*` will now disable generation of non-pointer cases in the `Set` method.