### PR TITLE
Add scalar to cosmos.proto FieldOptions

### DIFF
--- a/cosmos.proto
+++ b/cosmos.proto
@@ -13,4 +13,6 @@ extend google.protobuf.MessageOptions {
 
 extend google.protobuf.FieldOptions {
     string accepts_interface = 93001;
+
+    string scalar = 93002;
 }


### PR DESCRIPTION
Following this [suggestion](https://github.com/cosmos/cosmos-sdk/pull/9933#discussion_r690413814) from [Introduce Cosmos Scalars](https://github.com/cosmos/cosmos-sdk/pull/9933) PR, I would to like new `scalar` field to `FieldOptions` in  `cosmos.proto`